### PR TITLE
Remove Qt GUI module from project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@ moc_*.cpp
 qrc_*.cpp
 Makefile
 *build-*
+
+# Tests & examples
+examples/lrucache/lrucache
+tests/functional/functional
+tests/performance/performance
+
+# vim
+*.swp

--- a/examples/lrucache/lrucache.pro
+++ b/examples/lrucache/lrucache.pro
@@ -1,3 +1,4 @@
+QT -= gui
 SOURCES = \
     main.cpp
 

--- a/tests/functional/functional.pro
+++ b/tests/functional/functional.pro
@@ -1,3 +1,4 @@
+QT -= gui
 SOURCES = \
     testorderedmap.cpp
 

--- a/tests/performance/performance.pro
+++ b/tests/performance/performance.pro
@@ -1,3 +1,5 @@
+QT -= gui
+
 SOURCES = \
     main.cpp
 


### PR DESCRIPTION
Removed Qt GUI module from Qmake project files.

Updated .gitignore with more rules.