### PR TITLE
Fix assignment operator bug

### DIFF
--- a/tests/functional/testorderedmap.cpp
+++ b/tests/functional/testorderedmap.cpp
@@ -15,9 +15,6 @@ private slots:
     void emptyAndIsEmptyTest();
     void removeTest();
     void orderTest();
-#if QT_VERSION >= 0x040800
-    void swapTest();
-#endif
     void takeTest();
     void valueTest();
     void valuesTest();
@@ -139,29 +136,6 @@ void TestOrderedMap::orderTest()
     }
 }
 
-#if QT_VERSION >= 0x040800
-void TestOrderedMap::swapTest()
-{
-    OrderedMap<int, int> om1, om2;
-    om1.insert(1,1);
-    om1.insert(2,2);
-
-    om2.insert(3,3);
-    om2.insert(4,4);
-    om2.insert(5,5);
-
-    om1.swap(om2);
-
-    QVERIFY(om1.size() == 3);
-    QVERIFY(om2.size() == 2);
-    QVERIFY(om1.value(3) == 3);
-    QVERIFY(om1.value(4) == 4);
-    QVERIFY(om1.value(5) == 5);
-    QVERIFY(om2.value(1) == 1);
-    QVERIFY(om2.value(2) == 2);
-}
-#endif
-
 void TestOrderedMap::takeTest()
 {
     OrderedMap<int, int> om;
@@ -218,10 +192,66 @@ void TestOrderedMap::opAssignTest()
 
     om2 = om1;
 
-    QVERIFY(om2.size() == 3);
+    QVERIFY(om1.size() == 3);
+    QVERIFY(om1.keys().size() == 3);
     QVERIFY(om1.value(3) == 3);
     QVERIFY(om1.value(2) == 2);
     QVERIFY(om1.value(1) == 1);
+
+    QVERIFY(om2.size() == 3);
+    QVERIFY(om2.keys().size() == 3);
+    QVERIFY(om2.value(3) == 3);
+    QVERIFY(om2.value(2) == 2);
+    QVERIFY(om2.value(1) == 1);
+
+    om2.remove(2);
+    QVERIFY(om2.size() == 2);
+    QVERIFY(om2.keys().size() == 2);
+    QVERIFY(om2.value(3) == 3);
+    QVERIFY(om2.value(2) == 0); // default constructed value
+    QVERIFY(om2.value(1) == 1);
+    QVERIFY(om1.size() == 3);
+    QVERIFY(om1.keys().size() == 3);
+    QVERIFY(om1.value(3) == 3);
+    QVERIFY(om1.value(2) == 2);
+    QVERIFY(om1.value(1) == 1);
+
+    om2.remove(1);
+    QVERIFY(om2.size() == 1);
+    QVERIFY(om2.keys().size() == 1);
+    QVERIFY(om2.value(3) == 3);
+    QVERIFY(om2.value(2) == 0); // default constructed value
+    QVERIFY(om2.value(1) == 0); // default constructed value
+    QVERIFY(om1.size() == 3);
+    QVERIFY(om1.keys().size() == 3);
+    QVERIFY(om1.value(3) == 3);
+    QVERIFY(om1.value(2) == 2);
+    QVERIFY(om1.value(1) == 1);
+
+    om1.remove(3);
+    QVERIFY(om1.size() == 2);
+    QVERIFY(om1.keys().size() == 2);
+    QVERIFY(om1.value(3) == 0);
+    QVERIFY(om1.value(2) == 2); // default constructed value
+    QVERIFY(om1.value(1) == 1); // default constructed value
+    QVERIFY(om2.size() == 1);
+    QVERIFY(om2.value(3) == 3);
+    QVERIFY(om2.keys().size() == 1);
+
+    om1.insert(4,4);
+    om2.insert(5,5);
+
+    int om1_ans[] = { 2, 1, 4};
+    int om2_ans[] = { 3, 5};
+
+    int i = 0;
+    foreach (int v, om1.values()) {
+        QVERIFY(v == om1_ans[i++]);
+    }
+    i = 0;
+    foreach (int v, om2.values()) {
+        QVERIFY(v == om2_ans[i++]);
+    }
 }
 
 void TestOrderedMap::opEqualityTest()

--- a/tests/performance/main.cpp
+++ b/tests/performance/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     for (int i=0; i<itemCount; i++) {
         om.insert(i, QString::number(i));
     }
-    qDebug() << "Ordered ma :" << timer.elapsed() << "msecs";
+    qDebug() << "Ordered map :" << timer.elapsed() << "msecs";
     qDebug() << "\n";
 
     qDebug() << "Timing iteration over" << itemCount << "items...\n";


### PR DESCRIPTION
OrderedMap had a bug in it;s assignment operator which would
cause items deleted in the copy would delete corresponding
entries in the original ordered map.

This bug was caused due to OrderedMap storing iterators for
the linked list maintaining the insert order. Due to Qt
containers being implicitly shared, ot's not possible to
create copies on a container with active iterators. The
reason is that the iterator's maintain pointers to internal
state of the container and are hence any operation using them
will alter the state of the original container (even after
the container detaches, the iterator's still point to the
original container's state).

Fix (for now) is that when making a copy, invalidate old
iterators and regenrate new ones. This means copying
OrderedMap will take linear time.

Updated assignment operator unit test to have more coverage
and also be more correct.

TODO:
- Add copy constructor
- Enable implicit sharing