### PR TITLE
Fix breakage in lrucache example

### DIFF
--- a/examples/lrucache/lrucache.h
+++ b/examples/lrucache/lrucache.h
@@ -57,7 +57,7 @@ public:
         entries.remove(key);
     }
 
-    std::list<Key> keys() const {
+    QList<Key> keys() const {
         return entries.keys();
     }
 


### PR DESCRIPTION
31b354edfbd562043f99c811d4fa7e1eb24a7c3a changed the
OrderedMap::keys() API to return QList instead of std::list.
This broke the lrucache example. Fixed it to use the correct
type.