### PR TITLE
Add support for initializer list constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ moc_*.cpp
 qrc_*.cpp
 Makefile
 *build-*
+.qmake.stash
+.qmake.cache
+moc_predefs.h
 
 # Tests & examples
 examples/lrucache/lrucache

--- a/src/orderedmap.h
+++ b/src/orderedmap.h
@@ -7,6 +7,10 @@
 #include <QList>
 #include <QPair>
 
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+#include <initializer_list>
+#endif
+
 template <typename Key> inline bool oMHashEqualToKey(const Key &key1, const Key &key2)
 {
     // Key type must provide '==' operator
@@ -46,6 +50,10 @@ public:
     typedef typename OrderedMap<Key, Value>::const_iterator ConstIterator;
 
     explicit OrderedMap();
+
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+    OrderedMap(std::initializer_list<std::pair<Key,Value> > list);
+#endif
 
     OrderedMap(const OrderedMap<Key, Value>& other);
 
@@ -336,6 +344,17 @@ private:
 
 template <typename Key, typename Value>
 OrderedMap<Key, Value>::OrderedMap() {}
+
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+template<typename Key, typename Value>
+OrderedMap<Key, Value>::OrderedMap(std::initializer_list<std::pair<Key, Value> > list)
+{
+    typedef typename std::initializer_list<std::pair<Key,Value> >::const_iterator const_initlist_iter;
+    for (const_initlist_iter it = list.begin(); it != list.end(); ++it)
+        insert(it->first, it->second);
+}
+#endif
+
 
 template <typename Key, typename Value>
 OrderedMap<Key, Value>::OrderedMap(const OrderedMap<Key, Value>& other)

--- a/tests/functional/testorderedmap.cpp
+++ b/tests/functional/testorderedmap.cpp
@@ -10,6 +10,9 @@ class TestOrderedMap: public QObject
 
 private slots:
 
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+    void initializerListCtorTest();
+#endif
     void containsTest();
     void clearSizeCountTest();
     void emptyAndIsEmptyTest();
@@ -38,6 +41,19 @@ private slots:
     void foreachTest();
     void iteratorOperatorsTest();
 };
+
+#ifdef Q_COMPILER_INITIALIZER_LISTS
+void TestOrderedMap::initializerListCtorTest()
+{
+    OrderedMap<int, QString> om = {std::make_pair<int, QString>(0, QString("0")),
+                                   std::make_pair<int, QString>(1, QString("1"))};
+    QVERIFY(om.contains(0));
+    QVERIFY(om.contains(1));
+    QVERIFY(om.value(0) == QString("0"));
+    QVERIFY(om.value(1) == QString("1"));
+
+}
+#endif
 
 void TestOrderedMap::containsTest()
 {


### PR DESCRIPTION
OrderedMap can now be contructed using initializer list.

Eg:
OrderedMap<int,int> om = {std::make_pair<int,int>(0,0),
                          std::make_pair<int,int>(1,1)}

Added testcase to initialize an ordered map using initializer
list c'tor and verify keys and values exist.

Also, added new gitignore rules for qmake autogeneated  files.