### PR TITLE
Fix Qt version check for qt4

### DIFF
--- a/src/orderedmap.h
+++ b/src/orderedmap.h
@@ -57,7 +57,7 @@ public:
 
     OrderedMap(const OrderedMap<Key, Value>& other);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
     OrderedMap(OrderedMap<Key, Value>&& other);
 #endif
 
@@ -89,7 +89,7 @@ public:
 
     OrderedMap<Key, Value> & operator=(const OrderedMap<Key, Value>& other);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
     OrderedMap<Key, Value> & operator=(OrderedMap<Key, Value>&& other);
 #endif
 
@@ -362,7 +362,7 @@ OrderedMap<Key, Value>::OrderedMap(const OrderedMap<Key, Value>& other)
     copy(other);
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
 template <typename Key, typename Value>
 OrderedMap<Key, Value>::OrderedMap(OrderedMap<Key, Value>&& other)
 {
@@ -524,7 +524,7 @@ OrderedMap<Key, Value> & OrderedMap<Key, Value>::operator=(const OrderedMap<Key,
     return *this;
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
 template <typename Key, typename Value>
 OrderedMap<Key, Value> & OrderedMap<Key, Value>::operator=(OrderedMap<Key, Value>&& other)
 {

--- a/tests/functional/testorderedmap.cpp
+++ b/tests/functional/testorderedmap.cpp
@@ -23,7 +23,7 @@ private slots:
     void valuesTest();
     void copyConstructorTest();
     void opAssignTest();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
     void moveConstructorTest();
     void opMoveAssignTest();
 #endif
@@ -275,7 +275,7 @@ void TestOrderedMap::copyConstructorTest()
     }
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#if (QT_VERSION >= 0x050200)
 OrderedMap<int, int> genRValue()
 {
     OrderedMap<int, int> om1;


### PR DESCRIPTION
The QT_VERSION_CHECK is not expanded by moc, and does not
work as expected. Instead we need to compare the version
number returned by QT_VERSION with an integer. This works
for both qt4 & qt5.