### PR TITLE
Fix memory leak and a serious bug

### DIFF
--- a/src/orderedmap.h
+++ b/src/orderedmap.h
@@ -416,6 +416,7 @@ typename OrderedMap<Key, Value>::iterator OrderedMap<Key, Value>::insert(const K
     QllIterator ioIter = insertOrder.insert(insertOrder.end(), key);
     pair.first = value;
     pair.second = ioIter;
+    data.insert(key, pair);
     return iterator(ioIter, &data);
 }
 

--- a/tests/functional/testorderedmap.cpp
+++ b/tests/functional/testorderedmap.cpp
@@ -21,6 +21,7 @@ private slots:
     void takeTest();
     void valueTest();
     void valuesTest();
+    void singleKeyMultipleValuesTest();
     void copyConstructorTest();
     void opAssignTest();
 #if (QT_VERSION >= 0x050200)
@@ -180,6 +181,14 @@ void TestOrderedMap::valueTest()
     QVERIFY(om.value(1) == 1);
     QVERIFY(om.value(0) == 0);
     QVERIFY(om.value(2) == 2);
+
+    // overwrite with different values
+    om.insert(0, 10);
+    om.insert(2, 20);
+
+    QVERIFY(om.value(1) == 1);
+    QVERIFY(om.value(0) == 10);
+    QVERIFY(om.value(2) == 20);
 }
 
 void TestOrderedMap::valuesTest()
@@ -202,6 +211,16 @@ void TestOrderedMap::valuesTest()
     foreach (int v, om.values()) {
         QVERIFY(v == ans[i++]);
     }
+}
+
+void TestOrderedMap::singleKeyMultipleValuesTest()
+{
+    OrderedMap<int, int> om;
+    for (int i=0; i<10; i++) {
+        om.insert(1, i);
+    }
+    // only last value is retained
+    QVERIFY(om.value(1) == 9);
 }
 
 void TestOrderedMap::copyConstructorTest()


### PR DESCRIPTION
User "tycho-kirchner" discovered a memory bug (issue-22) that was caused
when the same key is inserted multiple times into OrderedMap. This was
a minor oversight that caused a major bug in OrderedMaps's
functionality. When inserting an existing key in the map, I delete the
corresponding entry in the linked list using the iterator stored, and
re-insert the key to the end of the linked list. However, I did not add
back this new iterator and value into the hashmap (OMHash). This meant
that the the key was holding the old value and an invalid iterator.
Because the old iterator pointed to an entry in linked list which was
deleted/free'd, it resulted in a memory leak (valgrind would show this
memory as unreachable and hence "leaking").

Fix was to add the new value-iterator pair into OMHash for the key being
inserted.

Updated unit tests to test for this condition.